### PR TITLE
Set correct ro.sf.lcd_density

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -81,7 +81,7 @@ PRODUCT_AAPT_PREBUILT_DPI := xxhdpi xhdpi hdpi
 PRODUCT_AAPT_PREF_CONFIG := xxhdpi
 
 PRODUCT_PROPERTY_OVERRIDES := \
-    ro.sf.lcd_density=480 \
+    ro.sf.lcd_density=420 \
     ro.usb.pid_suffix=1F3
 
 # Inherit from those products. Most specific first.


### PR DESCRIPTION
According to 50.2.A.3.55 /vendor it's set to 420 rather than 480.