### PR TITLE
[VOYAGER] mixer_paths: Add voice-headset alias for voice-headphones

### DIFF
--- a/rootdir/vendor/etc/mixer_paths.xml
+++ b/rootdir/vendor/etc/mixer_paths.xml
@@ -2037,6 +2037,10 @@
         <path name="headphones" />
     </path>
 
+    <path name="voice-headset">
+        <path name="voice-headphones" />
+    </path>
+
     <path name="voice-line">
         <path name="voice-headphones" />
     </path>


### PR DESCRIPTION
The CAF HAL relies on this route, otherwise calls with a wired headset
(speakers + microphone) will not work:

    E audio_route: unable to find path 'voice-headset'

These routes are identical, only their label is different between stock
and CAF. It is unknown whether calls through a wired headset were
working before on the AOSP HAL...
